### PR TITLE
Add README to docs/ — OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+# OctoAcme Project Management Docs
+
+This folder contains OctoAcme's project management process documentation. It provides a single place to find the project lifecycle, role definitions, checklists, and templates that teams use to initiate, plan, execute, release, and continuously improve work.
+
+Overview
+OctoAcme runs projects through a lightweight, repeatable lifecycle: Initiation (validate and authorize work with a Project One‑pager), Planning (break work into shippable backlog items, define acceptance criteria and a Definition of Done, create a release plan), Execution & Tracking (use a project board and disciplined PR/CI workflows to implement and verify work), Release & Deployment (checklists, smoke tests, rollback plans, and post‑deploy verification), and Retrospective & Continuous Improvement (capture learnings and convert them into tracked action items). Roles are explicit—Product Managers (define outcomes and prioritize), Project Managers (coordinate delivery and risks), Developers (implement and test), QA/Testing (validate acceptance criteria), and Stakeholders (provide input and approvals). Quality assurance is embedded via unit/integration tests, CI gating, security scans, and manual QA where needed.
+
+Quick links
+- Project Management Overview: docs/octoacme-project-management-overview.md
+- Project Initiation: docs/octoacme-project-initiation.md
+- Project Planning: docs/octoacme-project-planning.md
+- Execution & Tracking: docs/octoacme-execution-and-tracking.md
+- Risks & Communication: docs/octoacme-risks-and-communication.md
+- Release & Deployment: docs/octoacme-release-and-deployment.md
+- Retrospective & Continuous Improvement: docs/octoacme-retrospective-and-continuous-improvement.md
+- Roles & Personas: docs/octoacme-roles-and-personas.md
+
+How to use these documents
+- Keep the Project One‑pager and release docs current in the project repo as the single source of truth.
+- During initiation and planning, link or copy the One‑pager and project board skeleton into the project docs.
+- Use the templates and checklists before releases and at retrospectives to ensure consistent execution.
+- To propose changes or additions to these process docs, use the repository issue template: .github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml
+
+Contributing
+- If you find a gap, create an issue using the "Add Content to Project Management Process Docs" template, link the relevant doc, and propose the change.
+- Small edits may be submitted as PRs; larger or process-sensitive changes should be reviewed with PM and Product leads before merging.
+
+Contact / Questions
+- For process questions or to request a doc update, ping the Project Manager or open an issue in this repo.


### PR DESCRIPTION
Add a top-level README to docs/ that summarizes OctoAcme project management processes (initiation, planning, execution, tracking, risks, release, retrospectives, roles) and provides quick links to each process document.